### PR TITLE
Fixed INSTALLED_APPS as Django docs recommends (dotted path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ project/
 - To include this app in your project, add your app to the project's `settings.py` file by adding its name to the `INSTALLED_APPS` list:
 ```python
 INSTALLED_APPS = [
-	'app',
+	'app.apps.AppConfig',
 	# ...
 ]
 ```


### PR DESCRIPTION
A Django documentation [recommends](https://docs.djangoproject.com/en/3.0/ref/settings/#installed-apps) to include an application configuration class as a preferred method for INSTALLED_APPS list.